### PR TITLE
Add elasticsearch healthcheck.

### DIFF
--- a/arlas-exploration-stack-manager/Dockerfile
+++ b/arlas-exploration-stack-manager/Dockerfile
@@ -1,10 +1,7 @@
 FROM ubuntu:18.04
 
-ADD .env ARLAS-Exploration-stack.bash docker-compose.override.yml docker-compose.yml /
-
-ADD  environment /environment/default
-
-RUN apt-get update && \
+RUN docker_compose_version=1.22.0 && \
+   apt-get update && \
 # Installing docker
     apt-get -y install apt-transport-https ca-certificates curl \
     software-properties-common && \
@@ -16,7 +13,7 @@ RUN apt-get update && \
    apt-get update && \
    apt-get -y install docker-ce && \
 # Installing docker compose
-   curl -L https://github.com/docker/compose/releases/download/1.21.2/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose && \
+   curl -L "https://github.com/docker/compose/releases/download/$docker_compose_version/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
    chmod +x /usr/local/bin/docker-compose && \
 # Installing jq (dependency of yq)
    apt -y install jq && \
@@ -28,5 +25,9 @@ RUN apt-get update && \
    rm -f get-pip.py && \
 # Installing yq
    pip install yq
+
+ADD .env ARLAS-Exploration-stack.bash docker-compose.override.yml docker-compose.yml /
+
+ADD  environment /environment/default
 
 ENTRYPOINT ["/bin/bash", "-e", "/ARLAS-Exploration-stack.bash"]

--- a/arlas-exploration-stack-manager/docker-compose.override.yml
+++ b/arlas-exploration-stack-manager/docker-compose.override.yml
@@ -1,12 +1,15 @@
-version: "3"
+version: "3.6"
 
 services:
   elasticsearch:
+    container_name: arlas-exploration-stack-elasticsearch
     env_file:
       - /environment/default/arlas-exploration-stack-elasticsearch
       - /environment/user/arlas-exploration-stack-elasticsearch
+    healthcheck:
+      test: ( (( "$$(curl -o /dev/stderr -s -w "%{http_code}" localhost:9200)" == 200 )) && nc --send-only </dev/null -v localhost 9300) || exit 1
+      start_period: 30s
     image: docker.elastic.co/elasticsearch/elasticsearch:$ARLAS_EXPLORATION_STACK_ELASTICSEARCH_VERSION
-    container_name: arlas-exploration-stack-elasticsearch
     ports:
       - $ARLAS_EXPLORATION_STACK_ELASTICSEARCH_HTTP_PORT:9200
       - $ARLAS_EXPLORATION_STACK_ELASTICSEARCH_TRANSPORT_PORT:9300

--- a/arlas-exploration-stack-manager/docker-compose.yml
+++ b/arlas-exploration-stack-manager/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.6"
 
 networks:
   default:

--- a/docs/ARLAS-Exploration-Stack-Initializer.md
+++ b/docs/ARLAS-Exploration-Stack-Initializer.md
@@ -4,7 +4,7 @@ repository: https://github.com/gisaia/ARLAS-Exploration-stack/tree/master/arlas-
 
 # Prerequisites
 
-- [Docker CE](https://docs.docker.com/install/) (Community Edition)
+- [Docker CE](https://docs.docker.com/install/) (Community Edition) >= 18.02.0
 
 # Build
 

--- a/docs/ARLAS-Exploration-Stack-Manager.md
+++ b/docs/ARLAS-Exploration-Stack-Manager.md
@@ -6,7 +6,7 @@ repository: https://github.com/gisaia/ARLAS-Exploration-stack/tree/master/arlas-
 
 # Prerequisites
 
-- [Docker CE](https://docs.docker.com/install/) (Community Edition)
+- [Docker CE](https://docs.docker.com/install/) (Community Edition) >=  18.02.0
 
 # Build
 


### PR DESCRIPTION
Upgrade docker-compose files to version 3.6 to support `healthcheck` option `start_period`.
This bumps docker version requirement to ">= 18.02.0".
Manager: Place Dockerfile `RUN` directive @ the beginning, so that modifying a file does not re-execute the `RUN` directive.