### PR TITLE
feat: bump to wui, builder, hub and iam v27.0.1

### DIFF
--- a/conf/apisix/apisix_part_arlas_services.yaml
+++ b/conf/apisix/apisix_part_arlas_services.yaml
@@ -3,7 +3,7 @@ routes:
     uri: /builder
     upstream:
       nodes:
-        "arlas-builder:80": 1
+        "arlas-builder:8080": 1
     plugins:
       redirect:
         uri: /builder/
@@ -22,7 +22,7 @@ routes:
     uri: /builder/*
     upstream:
       nodes:
-        "arlas-builder:80": 1
+        "arlas-builder:8080": 1
       # response-rewrite:
       #   headers: 
       #     set:
@@ -78,7 +78,7 @@ routes:
     uri: /hub/*
     upstream:
       nodes:
-        "arlas-hub:80": 1
+        "arlas-hub:8080": 1
     plugins:
       response-rewrite:
         headers: 

--- a/conf/apisix/apisix_part_iam_services.yaml
+++ b/conf/apisix/apisix_part_iam_services.yaml
@@ -18,7 +18,7 @@
     uri: /iam/*
     upstream:
       nodes:
-        "arlas-wui-iam:80": 1
+        "arlas-wui-iam:8080": 1
     plugins:
       response-rewrite:
         headers: 

--- a/conf/apisix/apisix_with_iam.yaml
+++ b/conf/apisix/apisix_with_iam.yaml
@@ -3,7 +3,7 @@ routes:
     uri: /builder
     upstream:
       nodes:
-        "arlas-builder:80": 1
+        "arlas-builder:8080": 1
     plugins:
       redirect:
         uri: /builder/
@@ -22,7 +22,7 @@ routes:
     uri: /builder/*
     upstream:
       nodes:
-        "arlas-builder:80": 1
+        "arlas-builder:8080": 1
       # response-rewrite:
       #   headers: 
       #     set:
@@ -78,7 +78,7 @@ routes:
     uri: /hub/*
     upstream:
       nodes:
-        "arlas-hub:80": 1
+        "arlas-hub:8080": 1
     plugins:
       response-rewrite:
         headers: 
@@ -117,7 +117,7 @@ routes:
     uri: /iam/*
     upstream:
       nodes:
-        "arlas-wui-iam:80": 1
+        "arlas-wui-iam:8080": 1
     plugins:
       response-rewrite:
         headers: 

--- a/conf/versions.env
+++ b/conf/versions.env
@@ -1,7 +1,7 @@
-ARLAS_WUI_VERSION=gisaia/arlas-wui:27.0.0
-ARLAS_WUI_IAM_VERSION=gisaia/arlas-wui-iam:27.0.0
-ARLAS_BUILDER_VERSION=gisaia/arlas-wui-builder:27.0.0
-ARLAS_HUB_VERSION=gisaia/arlas-wui-hub:27.0.0
+ARLAS_WUI_VERSION=gisaia/arlas-wui:27.0.1
+ARLAS_WUI_IAM_VERSION=gisaia/arlas-wui-iam:27.0.1
+ARLAS_BUILDER_VERSION=gisaia/arlas-wui-builder:27.0.1
+ARLAS_HUB_VERSION=gisaia/arlas-wui-hub:27.0.1
 
 ARLAS_IAM_SERVER_VERSION=gisaia/arlas-iam-server:27.0.1
 ARLAS_PERMISSIONS_VERSION=gisaia/arlas-permissions-server:27.0.1

--- a/docs/docs/dc_services/docker_compose_services_aias.md
+++ b/docs/docs/dc_services/docker_compose_services_aias.md
@@ -182,7 +182,7 @@ Image: `ARLAS_IAM_SERVER_VERSION` with `gisaia/arlas-iam-server:27.0.1` in `conf
 ### Service arlas-wui-iam
 Description: ARLAS IAM is the ARLAS Identity and Access Management web interface.
 
-Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.0` in `conf/versions.env`
+Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -199,7 +199,7 @@ Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.0` in `conf/versi
 ### Service arlas-builder
 Description: ARLAS Builder is the interface for elaborating ARLAS Dashboards.
 
-Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/versions.env`
+Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -240,7 +240,7 @@ Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/v
 ### Service arlas-hub
 Description: ARLAS Hub is the interface for discovering all the available ARLAS Dashboards
 
-Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.env`
+Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -276,7 +276,7 @@ Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.
 ### Service arlas-wui
 Description: ARLAS WUI is ARLAS Web interface for visualising an analytic ARLAS Dashboard.
 
-Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.0` in `conf/versions.env`
+Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |

--- a/docs/docs/dc_services/docker_compose_services_iam.md
+++ b/docs/docs/dc_services/docker_compose_services_iam.md
@@ -173,7 +173,7 @@ Image: `ARLAS_IAM_SERVER_VERSION` with `gisaia/arlas-iam-server:27.0.1` in `conf
 ### Service arlas-wui-iam
 Description: ARLAS IAM is the ARLAS Identity and Access Management web interface.
 
-Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.0` in `conf/versions.env`
+Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -190,7 +190,7 @@ Image: `ARLAS_WUI_IAM_VERSION` with `gisaia/arlas-wui-iam:27.0.0` in `conf/versi
 ### Service arlas-builder
 Description: ARLAS Builder is the interface for elaborating ARLAS Dashboards.
 
-Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/versions.env`
+Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -231,7 +231,7 @@ Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/v
 ### Service arlas-hub
 Description: ARLAS Hub is the interface for discovering all the available ARLAS Dashboards
 
-Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.env`
+Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -267,7 +267,7 @@ Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.
 ### Service arlas-wui
 Description: ARLAS WUI is ARLAS Web interface for visualising an analytic ARLAS Dashboard.
 
-Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.0` in `conf/versions.env`
+Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |

--- a/docs/docs/dc_services/docker_compose_services_simple.md
+++ b/docs/docs/dc_services/docker_compose_services_simple.md
@@ -133,7 +133,7 @@ Image: `ARLAS_PERMISSIONS_VERSION` with `gisaia/arlas-permissions-server:27.0.1`
 ### Service arlas-builder
 Description: ARLAS Builder is the interface for elaborating ARLAS Dashboards.
 
-Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/versions.env`
+Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -174,7 +174,7 @@ Image: `ARLAS_BUILDER_VERSION` with `gisaia/arlas-wui-builder:27.0.0` in `conf/v
 ### Service arlas-hub
 Description: ARLAS Hub is the interface for discovering all the available ARLAS Dashboards
 
-Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.env`
+Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |
@@ -210,7 +210,7 @@ Image: `ARLAS_HUB_VERSION` with `gisaia/arlas-wui-hub:27.0.0` in `conf/versions.
 ### Service arlas-wui
 Description: ARLAS WUI is ARLAS Web interface for visualising an analytic ARLAS Dashboard.
 
-Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.0` in `conf/versions.env`
+Image: `ARLAS_WUI_VERSION` with `gisaia/arlas-wui:27.0.1` in `conf/versions.env`
 
 | Container variable | Value or environment variable | Default | Description | Env file setting |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
- starting from v27.0.1 of builder, hub and iam, these applications must be listened to on port 8080