### PR TITLE
Delete local conf only if it already exists

### DIFF
--- a/scripts/init_arlas_cli_confs.sh
+++ b/scripts/init_arlas_cli_confs.sh
@@ -103,7 +103,9 @@ arlas_cli --config-file /tmp/arlas-cli.yaml \
     --auth-org "" \
     --no-auth-arlas-iam
 
-arlas_cli --config-file /tmp/arlas-cli.yaml confs delete local
+if arlas_cli --config-file /tmp/arlas-cli.yaml confs list | grep -q " local "; then
+    arlas_cli --config-file /tmp/arlas-cli.yaml confs delete local
+fi
 
 arlas_cli --config-file /tmp/arlas-cli.yaml confs create local \
     --server http://${ARLAS_HOST}/arlas \


### PR DESCRIPTION
Change:

- In script to init arlas_cli confs, delete `local` conf only if it already exists