### PR TITLE
Fix/persistence

### DIFF
--- a/docs/docs/version.md
+++ b/docs/docs/version.md
@@ -1,1 +1,1 @@
-ARLAS Exploration Stack version 27.23
+ARLAS Exploration Stack version 27.24

--- a/k8s/charts/arlas-services/templates/arlas-persistence-file-persistent-volume-claim.yaml
+++ b/k8s/charts/arlas-services/templates/arlas-persistence-file-persistent-volume-claim.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: arlas-persistence-file-pvc
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     - ReadWriteOnce

--- a/k8s/charts/arlas-services/values.yaml
+++ b/k8s/charts/arlas-services/values.yaml
@@ -122,8 +122,8 @@ persistence:
   engine: file
   # -- Storage size in case of file persistence
   storageSize: 100Mi
-  # -- Storage engine to use: either `file` or `hibernate`
-  localFolder: /tmp/
+  # -- If file storage: path to local folder in the container
+  localFolder: /persistence/
   
   # -- Configuration node if `engine=hibernate`, ignored otherwise
   hibernate:


### PR DESCRIPTION
**Before:**
- on k8S deployment, persistence directory was not pointing to the right directory (mounted). It was on /tmp/. As a result, persistence was lost when restarting the service

**After:**
- persistence mounted on the mounted directory /persistence/
- the k8s pvc of persistence is marked as `keep` for it policy.