### PR TITLE
set jwks_uri in values.yaml

### DIFF
--- a/docs/docs/arlas_exploration_stack_helm.md
+++ b/docs/docs/arlas_exploration_stack_helm.md
@@ -64,7 +64,6 @@ global:
   elasticDnsDomain: &arlasAppElasticDnsDomain elastic.mydomain.k8s
   minioDnsDomain: &arlasAppMinioDnsDomain minio.mydomain.k8s
   keycloakDnsDomain: &arlasAppKeycloakDnsDomain keycloak.mydomain.k8s
-  openIdProvider: &arlasAppOpenIdProvider https://keycloak.mydomain.k8s/auth/realms/arlas/.well-known/openid-configuration
 ```
 
 IMPORTANT: the passwords must be configured before the first install of the chart!

--- a/docs/docs/helm/arlas-stack/README.md
+++ b/docs/docs/helm/arlas-stack/README.md
@@ -32,8 +32,8 @@ A Helm Chart to deploy the ARLAS Exploration Stack with AIAS services
 | aias-services.protocol | string | `"https"` | __Do not change:__ value defined in global section |
 | aias-services.services.agate.configuration.arlasUrlSearch | string | `"http://arlas-server:8000/arlas/explore/{collection}/_search?f=id:eq:{item}"` | ARLAS search URL used by Agate to check whether an item exists |
 | aias-services.services.agate.configuration.methodHeader | string | `"x-original-method"` | Headers used by the ingress controller to pass the original method information to Agate |
+| aias-services.services.agate.configuration.urbac.jwks_uri | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/protocol/openid-connect/certs"` | __MUST BE CONFIGURED:__ Change to the URI of the JWKS endpoint of your deployment. |
 | aias-services.services.agate.configuration.urbac.jwtAudience | string | `"arlas-backend"` | Name of the token audience |
-| aias-services.services.agate.configuration.urbac.openIdProvider | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/.well-known/openid-configuration"` |  |
 | aias-services.services.agate.configuration.urbac.verifySsl | bool | `false` | __MUST BE CONFIGURED:__ Change to true in production or if certificate can be verified |
 | aias-services.services.agate.configuration.urlHeader | string | `"x-auth-request-redirect"` | Headers used by the ingress controller to pass the original request information to Agate |
 | aias-services.services.agate.serviceName | string | `"arlas-agate"` | Agate service configuration for AIAS |
@@ -143,7 +143,6 @@ A Helm Chart to deploy the ARLAS Exploration Stack with AIAS services
 | global.minioDnsDomain | string | `"minio.arlas.k8s"` | __MUST BE CONFIGURED:__ The domain name for accessing minio for ARLAS deployment |
 | global.minioLogin | string | `"minioadmin"` | Minio login for minio itself and the services that are connecting to minio |
 | global.minioPassword | string | `"secret4minio"` | __MUST BE CONFIGURED:__ Minio password for minio itself and the services that are connecting to minio |
-| global.openIdProvider | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/.well-known/openid-configuration"` | __MUST BE CONFIGURED:__ The access to the openid-configuration |
 | global.organization | string | `"org.com"` | __MUST BE CONFIGURED:__ Name of the organization using AIAS |
 | global.postgresql.auth.password | string | `"secret4postgres"` | __MUST BE CONFIGURED:__ postgres password for keycloak |
 | global.protocol | string | `"https"` | __MUST BE CONFIGURED:__ The protocol for accessing the ARLAS deployment |

--- a/k8s/charts/arlas-stack/README.md
+++ b/k8s/charts/arlas-stack/README.md
@@ -32,8 +32,8 @@ A Helm Chart to deploy the ARLAS Exploration Stack with AIAS services
 | aias-services.protocol | string | `"https"` | __Do not change:__ value defined in global section |
 | aias-services.services.agate.configuration.arlasUrlSearch | string | `"http://arlas-server:8000/arlas/explore/{collection}/_search?f=id:eq:{item}"` | ARLAS search URL used by Agate to check whether an item exists |
 | aias-services.services.agate.configuration.methodHeader | string | `"x-original-method"` | Headers used by the ingress controller to pass the original method information to Agate |
+| aias-services.services.agate.configuration.urbac.jwks_uri | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/protocol/openid-connect/certs"` | __MUST BE CONFIGURED:__ Change to the URI of the JWKS endpoint of your deployment. |
 | aias-services.services.agate.configuration.urbac.jwtAudience | string | `"arlas-backend"` | Name of the token audience |
-| aias-services.services.agate.configuration.urbac.openIdProvider | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/.well-known/openid-configuration"` |  |
 | aias-services.services.agate.configuration.urbac.verifySsl | bool | `false` | __MUST BE CONFIGURED:__ Change to true in production or if certificate can be verified |
 | aias-services.services.agate.configuration.urlHeader | string | `"x-auth-request-redirect"` | Headers used by the ingress controller to pass the original request information to Agate |
 | aias-services.services.agate.serviceName | string | `"arlas-agate"` | Agate service configuration for AIAS |
@@ -143,7 +143,6 @@ A Helm Chart to deploy the ARLAS Exploration Stack with AIAS services
 | global.minioDnsDomain | string | `"minio.arlas.k8s"` | __MUST BE CONFIGURED:__ The domain name for accessing minio for ARLAS deployment |
 | global.minioLogin | string | `"minioadmin"` | Minio login for minio itself and the services that are connecting to minio |
 | global.minioPassword | string | `"secret4minio"` | __MUST BE CONFIGURED:__ Minio password for minio itself and the services that are connecting to minio |
-| global.openIdProvider | string | `"https://keycloak.arlas.k8s/auth/realms/arlas/.well-known/openid-configuration"` | __MUST BE CONFIGURED:__ The access to the openid-configuration |
 | global.organization | string | `"org.com"` | __MUST BE CONFIGURED:__ Name of the organization using AIAS |
 | global.postgresql.auth.password | string | `"secret4postgres"` | __MUST BE CONFIGURED:__ postgres password for keycloak |
 | global.protocol | string | `"https"` | __MUST BE CONFIGURED:__ The protocol for accessing the ARLAS deployment |

--- a/k8s/charts/arlas-stack/values.yaml
+++ b/k8s/charts/arlas-stack/values.yaml
@@ -11,9 +11,6 @@ global:
   # -- __MUST BE CONFIGURED:__ The domain name for accessing keycloak for ARLAS deployment
   keycloakDnsDomain: &arlasAppKeycloakDnsDomain keycloak.arlas.k8s
 
-  # -- __MUST BE CONFIGURED:__ The access to the openid-configuration
-  openIdProvider: &arlasAppOpenIdProvider https://keycloak.arlas.k8s/auth/realms/arlas/.well-known/openid-configuration
-
   # -- __MUST BE CONFIGURED:__ The protocol for accessing the ARLAS deployment
   protocol: &arlasAppProtocol https
 
@@ -300,11 +297,12 @@ aias-services:
         # -- Headers used by the ingress controller to pass the original method information to Agate
         methodHeader: x-original-method
         urbac:
-          openIdProvider: *arlasAppOpenIdProvider
           # -- Name of the token audience
           jwtAudience: arlas-backend
           # -- __MUST BE CONFIGURED:__ Change to true in production or if certificate can be verified
           verifySsl: false
+          # -- __MUST BE CONFIGURED:__ Change to the URI of the JWKS endpoint of your deployment.
+          jwks_uri: https://keycloak.arlas.k8s/auth/realms/arlas/protocol/openid-connect/certs
         # -- If a prefix is added to the arlas deployment, then you must add it to the path permissions below (change "myprefix" with your own prefix and uncomment).
         #roles: 
           # role/arlas/downloader:

--- a/k8s/scripts/configure_for_tests.sh
+++ b/k8s/scripts/configure_for_tests.sh
@@ -11,5 +11,4 @@ global:
     keycloakDnsDomain: &arlasAppKeycloakDnsDomain 'keycloak.${DOMAIN}'
     keycloak:
         url: &arlasAppKeycloakUrl 'https://keycloak.${DOMAIN}/auth'
-    authIssuer: &arlasAppAuthIssuer 'https://keycloak.${DOMAIN}/auth/realms/arlas'
-    openIdProvider: &arlasAppOpenIdProvider 'https://keycloak.${DOMAIN}/auth/realms/arlas/.well-known/openid-configuration'" > custom_values.yaml
+    authIssuer: &arlasAppAuthIssuer 'https://keycloak.${DOMAIN}/auth/realms/arlas'" > custom_values.yaml


### PR DESCRIPTION
`openIdProvider` is not use since a couple of releases by agate, instead `jwks_uri` is used to point to the public certificate for token validation.