### PR TITLE
feat: register Satellogic driver in Helm values

### DIFF
--- a/k8s/charts/aias-services/values.yaml
+++ b/k8s/charts/aias-services/values.yaml
@@ -466,6 +466,9 @@ services:
             landsat:
               enabled: true
               priority: 19
+            satellogic:
+              enabled: true
+              priority: 20
             tiff:
               enabled: true
               priority: 100


### PR DESCRIPTION
## Summary

- Add Satellogic ingest driver entry in Helm values with priority 20, between landsat and the generic tiff catch-all driver

## Test plan

- [ ] Verify Helm template renders correctly with the new driver entry
- [ ] Deploy and confirm Satellogic driver is loaded by aproc